### PR TITLE
GHA add sudo for apt on main runner

### DIFF
--- a/.github/workflows/debian-package.yaml
+++ b/.github/workflows/debian-package.yaml
@@ -26,8 +26,8 @@ jobs:
           DEBIAN_FRONTEND: noninteractive
           TZ: Etc/UTC
         run: |
-          apt-get update -qq
-          apt-get install -qqy \
+          sudo apt-get update -qq
+          sudo apt-get install -qqy \
             build-essential \
             debhelper \
             devscripts \
@@ -41,8 +41,8 @@ jobs:
           DEBIAN_FRONTEND: noninteractive
           TZ: Etc/UTC
         run: |
-          apt-get update -qq
-          apt-get install -qqy \
+          sudo apt-get update -qq
+          sudo apt-get install -qqy \
             pybuild-plugin-pyproject \
             python3-all \
             python3-dateutil \


### PR DESCRIPTION
Only update Debian workflow to use `sudo` for apt when in main runner. 

### Testing 
https://github.com/mstanojlovic/py-pure-client/actions/runs/27678941562/job/81861165069
